### PR TITLE
provide option to use personal python binary 

### DIFF
--- a/R/data_processing.R
+++ b/R/data_processing.R
@@ -368,10 +368,12 @@ write_anndata <- function(data, path) {
 #' If called and python environment is not set up, this is realized. Else, it checks if the anndata
 #' package is loaded, and if not, it does this.
 #'
-anndata_checkload <- function() {
+#' @param python (optional) If own python should be used please indicate it's binaries
+#'
+anndata_checkload <- function(python = NULL) {
   if (!python_available()) {
     base::message("Setting up python environment..")
-    init_python()
+    init_python(python)
     if (!python_available()) {
       base::stop(
         "Could not initiate miniconda python environment. Please set up manually with ",

--- a/R/deconvolution_algorithms.R
+++ b/R/deconvolution_algorithms.R
@@ -485,11 +485,13 @@ calc_condition_number <- function(signature_matrix) {
 #' This makes sure a valid python installation exists and all needed packages are pulled and
 #' installed.
 #'
+#' @param python (optional) If own python should be used please indicate it's binaries
+#'
 #' @export
 #'
-install_all_python <- function() {
-  init_python()
-  anndata_checkload()
+install_all_python <- function(python = NULL) {
+  init_python(python)
+  anndata_checkload(python)
   autogenes_checkload()
   scaden_checkload()
 }

--- a/R/helper.R
+++ b/R/helper.R
@@ -199,6 +199,9 @@ set_python <- function(path_to_python_binaries) {
 #' @param python (optional) If own python should be used please indicate it's binaries
 #'
 init_python <- function(python = NULL) {
+  # check the python config first; this also enables py_available to work correctly, otherwise it can be that the
+  # correct python path is set, but py_available does not recognize it
+  reticulate::py_config()
   if (!reticulate::py_available()) {
     if (is.null(python)) {
       if (!dir.exists(reticulate::miniconda_path())) {
@@ -228,6 +231,7 @@ init_python <- function(python = NULL) {
 #' @return boolean
 #'
 python_available <- function() {
+  reticulate::py_config()
   return(reticulate::py_available())
 }
 

--- a/man/anndata_checkload.Rd
+++ b/man/anndata_checkload.Rd
@@ -4,7 +4,10 @@
 \alias{anndata_checkload}
 \title{Checks if anndata package is loaded}
 \usage{
-anndata_checkload()
+anndata_checkload(python = NULL)
+}
+\arguments{
+\item{python}{(optional) If own python should be used please indicate it's binaries}
 }
 \description{
 If called and python environment is not set up, this is realized. Else, it checks if the anndata

--- a/man/install_all_python.Rd
+++ b/man/install_all_python.Rd
@@ -4,7 +4,10 @@
 \alias{install_all_python}
 \title{Install all python packages}
 \usage{
-install_all_python()
+install_all_python(python = NULL)
+}
+\arguments{
+\item{python}{(optional) If own python should be used please indicate it's binaries}
 }
 \description{
 This makes sure a valid python installation exists and all needed packages are pulled and


### PR DESCRIPTION
(and therefore conda env) when installing omnideconv. Also add py_config() call in python_available function to enable correct use of reticulate::py_available()