### PR TITLE
scaden fix: 

### DIFF
--- a/R/Scaden.R
+++ b/R/Scaden.R
@@ -236,7 +236,6 @@ scaden_process <- function(h5ad, temp_dir = NULL, bulk_gene_expression, var_cuto
 
   out <- tryCatch(
     {
-      tmp_dir <- tempdir()
       dir.create(tmp_dir, showWarnings = FALSE)
 
       h5ad_tmp <- tempfile(tmpdir = tmp_dir, fileext = ".h5ad")


### PR DESCRIPTION
dont create tempdir() in scaden_process as it overwrites the temp_dir parameter.

@LorenzoMerotto I guess you missed this in the previous scaden fix. 