### PR TITLE
added python parameter to init functions

### DIFF
--- a/R/AutoGeneS.R
+++ b/R/AutoGeneS.R
@@ -277,10 +277,10 @@ install_autogenes <- function() {
 
 #' Checks if python and the autogenes module are available and installs them if they are not.
 #'
-autogenes_checkload <- function() {
+autogenes_checkload <- function(python=NULL) {
   if (!python_available()) {
     message("Setting up python environment..")
-    init_python()
+    init_python(python)
     if (!python_available()) {
       stop(
         "Could not initiate miniconda python environment. Please set up manually with ",

--- a/R/AutoGeneS.R
+++ b/R/AutoGeneS.R
@@ -277,7 +277,7 @@ install_autogenes <- function() {
 
 #' Checks if python and the autogenes module are available and installs them if they are not.
 #'
-autogenes_checkload <- function(python=NULL) {
+autogenes_checkload <- function(python = NULL) {
   if (!python_available()) {
     message("Setting up python environment..")
     init_python(python)

--- a/R/Scaden.R
+++ b/R/Scaden.R
@@ -471,10 +471,10 @@ scaden_simulate <- function(cell_type_annotations, gene_labels, single_cell_obje
 #'
 #' If it is available, the python module is imported.
 #'
-scaden_checkload <- function() {
+scaden_checkload <- function(python=NULL) {
   if (!python_available()) {
     message("Setting up python environment..")
-    init_python()
+    init_python(python)
     if (!python_available()) {
       stop(
         "Could not initiate miniconda python environment. Please set up manually with ",

--- a/R/Scaden.R
+++ b/R/Scaden.R
@@ -471,7 +471,7 @@ scaden_simulate <- function(cell_type_annotations, gene_labels, single_cell_obje
 #'
 #' If it is available, the python module is imported.
 #'
-scaden_checkload <- function(python=NULL) {
+scaden_checkload <- function(python = NULL) {
   if (!python_available()) {
     message("Setting up python environment..")
     init_python(python)

--- a/man/autogenes_checkload.Rd
+++ b/man/autogenes_checkload.Rd
@@ -4,7 +4,7 @@
 \alias{autogenes_checkload}
 \title{Checks if python and the autogenes module are available and installs them if they are not.}
 \usage{
-autogenes_checkload()
+autogenes_checkload(python = NULL)
 }
 \description{
 Checks if python and the autogenes module are available and installs them if they are not.

--- a/man/scaden_checkload.Rd
+++ b/man/scaden_checkload.Rd
@@ -4,7 +4,7 @@
 \alias{scaden_checkload}
 \title{Checks if scaden is installed.}
 \usage{
-scaden_checkload()
+scaden_checkload(python = NULL)
 }
 \description{
 If it is available, the python module is imported.


### PR DESCRIPTION
I added the python path parameter to autogenes_checkload and scaden_checkload, they will throw errors otherwise in "install_all_python". Currently install_all_python is passing the python parameter but not implemented in the respective functions.